### PR TITLE
Change submodule repo / commit for logic bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thrift"]
 	path = thrift
-	url = https://github.com/alexanderedge/thrift.git
+	url = https://github.com/guardian/french-thrift.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thrift"]
 	path = thrift
-	url = https://github.com/apache/thrift.git
+	url = https://github.com/alexanderedge/thrift.git


### PR DESCRIPTION
This is getting fairly complicated.

## The problem
There is a bug in the Swift multiplexing support I added and I have opened a PR to fix it https://github.com/apache/thrift/pull/2036. Until it's merged upstream, we're stuck unable to use multiplexing on iOS.

<strike>## A solution (this PR)
I've updated the git submodule to point to the branch from which https://github.com/apache/thrift/pull/2036 is based. This is my own fork of the Apache Thrift repository, so from a risk perspective it's not good. However, it is only temporary.

## An alternative solution
The Guardian forks Apache Thrift, we merge these changes into `master`, and we open a PR to merge the changes upstream to Apache. Unfortunately The Guardian already have a fork of Thrift (https://github.com/guardian/french-thrift) but I don't know if it's being actively used.</strike>

I've brought https://github.com/guardian/french-thrift up to date with apache/thrift and have made a branch, `mobile-apps`, that we can use for any changes that we need to make to Thrift.

