### PR TITLE
Replace french-thrift with Apache Thrift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thrift"]
 	path = thrift
-	url = https://github.com/guardian/french-thrift.git
+	url = https://github.com/apache/thrift.git


### PR DESCRIPTION
## What does this change?

This is the first stage in decommissioning french-thrift, since we have ascertained [here](https://docs.google.com/document/d/1JBGej-2Adn3UrzRMNSlGYn5vWA3Gu4oD4b1ZtyPfWXU/edit?tab=t.0) that it is no longer needed. The full list of steps required to complete this process is documented [here](https://theguardian.atlassian.net/browse/LIVE-7287). 

For the benefit of future travellers: I created the second commit in this PR by running `git submodule update --init --recursive --remote` in my terminal after I'd updated the submodule URL locally.  

## How to test
After merging, we will create and push the tag v0.21.0 on this repository (the current [latest](https://github.com/apache/thrift/releases/tag/v0.21.0) version of Apache Thrift) and create a new release, so that we can then update the version of this library used by Bridget and Ophan Thrift Swift. 