### PR TITLE
Revert "Replace french-thrift with Apache Thrift"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thrift"]
 	path = thrift
-	url = https://github.com/apache/thrift.git
+	url = https://github.com/guardian/french-thrift.git


### PR DESCRIPTION
Reverts guardian/thrift-swift#8

After I merged https://github.com/guardian/bridget/pull/175, the [validate-thrift](https://github.com/guardian/bridget/actions/runs/12141551063) GitHub Action in the Bridget repo failed. A bit of digging led me to [this](https://github.com/apache/thrift/pull/1997) closed PR in the Apache Thrift repo by David Furey from March 2020.

From what I can see, these changes never got merged into Apache Thrift, but were made in the French Thrift repo (as [commits](https://github.com/apache/thrift/compare/master...guardian:french-thrift:mobile-apps) straight to master, rather than as PRs), so we can't just do a straight swap of French Thrift for Apache Thrift.

I'm reverting this PR for now while I consider the best next steps, which might be to resubmit the [original](https://github.com/apache/thrift/pull/1997) PR introducing an async server implementation for Swift to Apache Swift. Alternatively, we could update French Thrift to the latest Apache Thrift version, which might eliminate the vulnerabilities that started this process.

Once this is merged, I'll also delete the 0.21.0 release and tag to avoid any confusion.